### PR TITLE
feat: Migrate deprecated guard to sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ const loginForm = createForm({
   },
 })
 
-guard({
+sample({
   source: loginFx.failData.map(
     (error) => error.name === "already-exists" ? { rule: "already-exists" } : null
   ),
@@ -859,7 +859,7 @@ guard({
 You can add multiple errors for many fields at once with the form.addErrors event:
 
 ```ts
-guard({
+sample({
   clock: loginFx.failData.map(
     (errors) => errors.map((err) => ({
       field: err.field,

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -3,8 +3,6 @@ import {
     Store,
     combine,
     sample,
-    guard,
-    createStore,
 } from "effector"
 import {
     AnyFields,
@@ -205,14 +203,14 @@ export function createForm<Values extends AnyFormValues>(
         }, { sid: fieldName })
     }
 
-    guard({
+    sample({
         source: submitWithFormData as unknown as Event<Values>,
         filter: $isFormValid,
         // TODO: fix
         target: formValidated,
     })
 
-    guard({
+    sample({
         source: validateWithFormData as unknown as Event<Values>,
         filter: $isFormValid,
         target: formValidated,

--- a/src/field.ts
+++ b/src/field.ts
@@ -5,7 +5,6 @@ import {
     Store,
     combine,
     sample,
-    guard,
     merge,
 } from "effector"
 import {
@@ -374,9 +373,10 @@ export function bindChangeEvent({
         .on(changed, () => true)
         .reset(reset, resetForm, resetTouched)
 
-    guard({
+    // @ts-expect-error There is two possible overloads for sample, so TS can't decide
+    sample({
         source: onChange,
-        filter: filter || (() => true),
+        filter: filter ?? (() => true),
         target: changed,
     })
 


### PR DESCRIPTION
Get rid of deprecated `guard` operator

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github/sqreder/effector-forms/tree/master"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz Codeflow" align="left" width="103" height="20"></a> _Submitted with [StackBlitz Codeflow](https://stackblitz.com/~/github/sqreder/effector-forms/tree/master)._